### PR TITLE
Documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ The advised way of running the examples is to create a new project from existing
 
 Alternatively you can run the samples from the command line using `./gradlew :<project-name>:run`
 
-Note that on OSX an additional step is required. The JVM argument `-XrunOnFirstThread` has to be added in the run configuration. When running the examples from the command line this has been taken care of. 
+Note that on OSX an additional step is required. The JVM argument `-XstartOnFirstThread` has to be added in the run configuration. When running the examples from the command line this has been taken care of. 


### PR DESCRIPTION
Was trying to run some of these examples, but was getting the following error:

> Error occurred during initialization of VM
Could not find agent library OnFirstThread on the library path, with error: dlopen(libOnFirstThread.dylib, 1): image not found

Noticed the getting started guide calls for the VM Option `-XstartOnFirstThread` instead of `-XrunOnFirstThread`. Updated and things worked.