### PR TITLE
Make all examples runnable with ./gradlew

### DIFF
--- a/composition-drawer-001/build.gradle
+++ b/composition-drawer-001/build.gradle
@@ -1,0 +1,2 @@
+apply plugin: 'java'
+apply plugin: 'kotlin'

--- a/composition-drawer-001/src/main/kotlin/Example.kt
+++ b/composition-drawer-001/src/main/kotlin/Example.kt
@@ -13,7 +13,7 @@ import java.io.File
  * Demonstrates the use of CompositionDrawer and Composition.saveToFile to
  * easily write SVG files.
  */
-class CompositionDrawer001: Program() {
+class Example: Program() {
 
     lateinit var composition: Composition
     override fun setup() {
@@ -33,5 +33,5 @@ class CompositionDrawer001: Program() {
 }
 
 fun main(args: Array<String>) {
-    application(CompositionDrawer001(), configuration{})
+    application(Example(), configuration{})
 }

--- a/coroutines-001/src/main/kotlin/Example.kt
+++ b/coroutines-001/src/main/kotlin/Example.kt
@@ -12,7 +12,7 @@ import org.openrndr.draw.renderTarget
 import org.openrndr.filter.blend.passthrough
 import org.openrndr.internal.Driver
 
-class Coroutines001 : Program() {
+class Example : Program() {
     override fun setup() {
         // -- we need a nicer api for this in the near future
         val drawThread = Driver.driver.createDrawThread()
@@ -66,4 +66,4 @@ class Coroutines001 : Program() {
     }
 }
 
-fun main() = application(Coroutines001(), configuration { })
+fun main() = application(Example(), configuration { })

--- a/image-001/src/main/kotlin/Example.kt
+++ b/image-001/src/main/kotlin/Example.kt
@@ -6,7 +6,7 @@ import org.openrndr.draw.loadImage
 /**
  * This is a basic example that shows how to load and draw images
  */
-class Image001 : Program() {
+class Example : Program() {
     override fun setup() {
         val image = loadImage("file:data/images/test_pattern.png")
         extend {
@@ -15,4 +15,4 @@ class Image001 : Program() {
     }
 }
 
-fun main() = Application.run(Image001(), Configuration())
+fun main() = Application.run(Example(), Configuration())

--- a/image-002/src/main/kotlin/Example.kt
+++ b/image-002/src/main/kotlin/Example.kt
@@ -8,7 +8,7 @@ import org.openrndr.draw.tint
 /**
  * This is a basic example that shows how to load and draw images and apply tinting
  */
-class Image002 : Program() {
+class Example : Program() {
     override fun setup() {
         val image = loadImage("file:data/images/test_pattern.png")
         extend {
@@ -22,4 +22,4 @@ class Image002 : Program() {
     }
 }
 
-fun main() = Application.run(Image002(), Configuration())
+fun main() = Application.run(Example(), Configuration())

--- a/screenshots-001/build.gradle
+++ b/screenshots-001/build.gradle
@@ -1,0 +1,2 @@
+apply plugin: 'java'
+apply plugin: 'kotlin'

--- a/screenshots-001/src/main/kotlin/Example.kt
+++ b/screenshots-001/src/main/kotlin/Example.kt
@@ -9,7 +9,7 @@ import org.openrndr.extensions.Screenshots
  * Demonstrates the Screenshots extension
  * Screenshots are taken by pressing the space bar
  */
-class Screenshots001: Program() {
+class Example: Program() {
 
     override fun setup() {
         // -- install the Screenshots extension
@@ -29,6 +29,6 @@ class Screenshots001: Program() {
 }
 
 fun main(args: Array<String>) {
-    application(Screenshots001(), configuration {  })
+    application(Example(), configuration {  })
 
 }

--- a/shape-boolean-001/build.gradle
+++ b/shape-boolean-001/build.gradle
@@ -1,0 +1,2 @@
+apply plugin: 'java'
+apply plugin: 'kotlin'

--- a/shape-boolean-001/src/main/kotlin/Example.kt
+++ b/shape-boolean-001/src/main/kotlin/Example.kt
@@ -5,7 +5,7 @@ import org.openrndr.configuration
 import org.openrndr.math.Vector2
 import org.openrndr.shape.*
 
-class ShapeBoolean001 : Program() {
+class Example : Program() {
     override fun draw() {
         val a = Circle(Vector2(width / 2.0, height / 2.0), 100.0).contour
         val b = Circle(mouse.position, 70.0).contour
@@ -29,6 +29,6 @@ class ShapeBoolean001 : Program() {
 }
 
 fun main(args: Array<String>) {
-    application(ShapeBoolean001(), configuration {  })
+    application(Example(), configuration {  })
 
 }

--- a/shape-contour-offset-001/build.gradle
+++ b/shape-contour-offset-001/build.gradle
@@ -1,0 +1,2 @@
+apply plugin: 'java'
+apply plugin: 'kotlin'

--- a/shape-contour-offset-001/src/main/kotlin/Example.kt
+++ b/shape-contour-offset-001/src/main/kotlin/Example.kt
@@ -6,7 +6,7 @@ import org.openrndr.math.Vector2
 import org.openrndr.shape.Rectangle
 import org.openrndr.shape.SegmentJoin
 
-class ShapeContourOffset001: Program() {
+class Example: Program() {
 
     override fun draw() {
         drawer.fill = null
@@ -23,7 +23,7 @@ class ShapeContourOffset001: Program() {
 }
 
 fun main(args: Array<String>) {
-    application(ShapeContourOffset001(), configuration {
+    application(Example(), configuration {
 
     })
 


### PR DESCRIPTION
Was running a few of the tutorials and noticed not all of them were runnable using the documented command `./gradlew :<project-name>:run`. Updated each tutorial to conform to the `Example.kt` pattern and ensured all tutorials contained a gradle build file.